### PR TITLE
Adjust dependency 

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
         }
     ],
     "require": {
-        "illuminate/contracts": "^5.6"
+        "illuminate/contracts": "^5.5"
     },
     "require-dev": {
         "orchestra/testbench": "^3.6",


### PR DESCRIPTION
This should be compatible with Laravel 5.5, right? Would it be fine to adjust the dependency for `illuminate/contracts` to 5.5?